### PR TITLE
Add Prometheus metrics support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-health",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "config",
  "console-subscriber",
  "hyper",
+ "prometheus",
  "serde 1.0.136",
  "tokio",
  "tonic",
@@ -527,6 +528,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1007,6 +1014,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e344cafeaeefe487300c361654bcfc85db3ac53619eeccced29f5ea18c4c70"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1096,12 @@ dependencies = [
  "bytes",
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quickcheck"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,6 +14,10 @@ install_crate = "cargo-nextest"
 command = "cargo"
 args = ["nextest", "run"]
 
+[tasks.docs]
+command = "cargo"
+args = ["doc"]
+
 [tasks.grpc]
 install_crate = "grpc-build"
 command = "grpc_build"

--- a/chainsaw-demo/Cargo.toml
+++ b/chainsaw-demo/Cargo.toml
@@ -16,6 +16,7 @@ chainsaw-proto = { version = "0.1", path = "../chainsaw-proto" }
 
 # http application framework
 axum = "0.4.5"
+tower = "0.4.11"
 tower-http = { version = "0.2.2", features = ["trace"] }
 hyper = "0.14.17"
 

--- a/chainsaw-demo/Cargo.toml
+++ b/chainsaw-demo/Cargo.toml
@@ -30,6 +30,9 @@ tracing-error = "0.2"
 tracing-log = "0.1"
 color-eyre = "0.6"
 
+# metrics
+prometheus = { version = "0.13", features = ["process"] }
+
 # configuration
 config = "0.11"
 serde = { version = "1.0", features = ["derive"] }

--- a/chainsaw-demo/src/bin/chainsaw-demo-grpc/config.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-grpc/config.rs
@@ -5,19 +5,19 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct Chainsaw {
-    pub grpc: GRPC,
+    pub grpc: Grpc,
 
     pub log: Log,
 }
 
 #[derive(Deserialize)]
-pub struct GRPC {
+pub struct Grpc {
     #[serde(default = "default_grpc_address")]
     pub address: IpAddr,
     pub port: u16,
 }
 
-impl GRPC {
+impl Grpc {
     pub fn serve_addr(&self) -> SocketAddr {
         SocketAddr::new(self.address, self.port)
     }

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/config.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/config.rs
@@ -5,19 +5,19 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct Chainsaw {
-    pub http: HTTP,
+    pub http: Http,
 
     pub log: Log,
 }
 
 #[derive(Deserialize)]
-pub struct HTTP {
+pub struct Http {
     #[serde(default = "default_http_address")]
     pub address: IpAddr,
     pub port: u16,
 }
 
-impl HTTP {
+impl Http {
     pub fn serve_addr(&self) -> SocketAddr {
         SocketAddr::new(self.address, self.port)
     }

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/greeter.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/greeter.rs
@@ -1,6 +1,11 @@
-use axum::extract::Path;
+use axum::extract::{Extension, Path};
+use prometheus::Counter;
 
 #[tracing::instrument]
-pub async fn greeter(Path((name, surname)): Path<(String, String)>) -> String {
+pub async fn greeter(
+    Path((name, surname)): Path<(String, String)>,
+    Extension(counter_metric): Extension<Counter>,
+) -> String {
+    counter_metric.inc();
     format!("Hello, {name} {surname}!\n")
 }

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/main.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/main.rs
@@ -1,10 +1,12 @@
-use crate::config::get_configuration;
-use axum::{routing, Router};
+use crate::{config::get_configuration, metrics::report_metrics};
+use axum::{routing, AddExtensionLayer, Router};
 use chainsaw_demo::{logging, Result};
+use prometheus::Registry;
 use tokio::signal;
 
 mod config;
 mod greeter;
+mod metrics;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -13,18 +15,27 @@ async fn main() -> Result<()> {
     let subscriber = logging::new_subscriber(configuration.log.level)?;
     logging::set_global_logger(subscriber)?;
 
+    let metrics_registry = Registry::new();
+    let example_counter = metrics::new_example_counter(
+        "example_counter",
+        "Reflects the number of times the greeter endpoint has been called.",
+    )?;
+    metrics_registry.register(Box::new(example_counter.clone()))?;
+
     let http_addr = configuration.http.serve_addr();
     let http_router = Router::new()
         .route("/:name/:surname", routing::get(greeter::greeter))
+        .route("/metrics", routing::get(report_metrics))
+        .layer(AddExtensionLayer::new(metrics_registry))
+        .layer(AddExtensionLayer::new(example_counter))
         .layer(logging::http_trace_layer());
     let http = axum::Server::bind(&http_addr).serve(http_router.into_make_service());
 
     tracing::info!(?http, "Revving up HTTP Chainsaw!");
     tokio::spawn(http);
 
-    signal::ctrl_c()
-        .await
-        .expect("Unable to listen for shutdown signal.");
+    // Exit if SIGINT received.
+    signal::ctrl_c().await?;
     tracing::info!("Revving down Chainsaw...");
     Ok(())
 }

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/main.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/main.rs
@@ -15,7 +15,8 @@ async fn main() -> Result<()> {
     let subscriber = logging::new_subscriber(configuration.log.level)?;
     logging::set_global_logger(subscriber)?;
 
-    // Create a Prometheus registry and register an example metric.
+    // Create a Prometheus registry and register an example metric. Sharing
+    // across threads is fine as both Registry and Counter are `Send + Sync`.
     let metrics_registry = Registry::new();
     let example_counter = metrics::new_example_counter(
         "example_counter",

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/main.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/main.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<()> {
     let subscriber = logging::new_subscriber(configuration.log.level)?;
     logging::set_global_logger(subscriber)?;
 
+    // Create a Prometheus registry and register an example metric.
     let metrics_registry = Registry::new();
     let example_counter = metrics::new_example_counter(
         "example_counter",
@@ -22,6 +23,7 @@ async fn main() -> Result<()> {
     )?;
     metrics_registry.register(Box::new(example_counter.clone()))?;
 
+    // Create HTTP router with greeter and metric endpoints.
     let http_addr = configuration.http.serve_addr();
     let http_router = Router::new()
         .route("/:name/:surname", routing::get(greeter::greeter))

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
@@ -1,9 +1,27 @@
+//! Provides a HTTP handler for exposing metrics to a Prometheus scraper.
+
 use crate::Result;
 
 use axum::extract::Extension;
 use hyper::StatusCode;
 use prometheus::{Counter, Encoder, Opts, Registry, TextEncoder};
 
+/// HTTP endpoint that exposes all registered metrics to a Prometheus scrape
+/// run.
+///
+/// In order to gather metrics from the registry, you should use
+/// [`axum::AddExtensionLayer`] to expose your registry to this handler.
+///
+/// # Example
+///
+/// ```
+/// let metrics_registry = Registry::new();
+/// // register any metrics
+///
+/// let http_router = Router::new()
+///     // add any routes or other layers
+///     .layer(AddExtensionLayer::new(metrics_registry));
+/// ```
 pub async fn report_metrics(
     Extension(metrics_registry): Extension<Registry>,
 ) -> Result<String, StatusCode> {
@@ -11,9 +29,9 @@ pub async fn report_metrics(
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
     let metric_families = metrics_registry.gather();
-    if let Err(_) = encoder.encode(&metric_families, &mut buffer) {
+    if encoder.encode(&metric_families, &mut buffer).is_err() {
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
-    };
+    }
 
     match String::from_utf8(buffer) {
         Ok(metrics) => Ok(metrics),
@@ -21,6 +39,7 @@ pub async fn report_metrics(
     }
 }
 
+/// Returns a new Prometheus counter with a given name and help string.
 pub fn new_example_counter<S: Into<String>>(name: S, help: S) -> Result<Counter> {
     let opts = Opts::new(name.into(), help.into());
     Ok(Counter::with_opts(opts)?)

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
@@ -4,7 +4,7 @@ use crate::Result;
 
 use axum::extract::Extension;
 use hyper::StatusCode;
-use prometheus::{Counter, Encoder, Opts, Registry, TextEncoder};
+use prometheus::{Counter, Opts, Registry, TextEncoder};
 
 /// HTTP endpoint that exposes all registered metrics to a Prometheus scrape
 /// run.
@@ -25,9 +25,10 @@ use prometheus::{Counter, Encoder, Opts, Registry, TextEncoder};
 pub async fn report_metrics(
     Extension(metrics_registry): Extension<Registry>,
 ) -> Result<String, StatusCode> {
-    // Gather the metrics.
+    // Create a new Prometheus text encoder, and gather all our metrics.
     let encoder = TextEncoder::new();
     let metric_families = metrics_registry.gather();
+
     match encoder.encode_to_string(&metric_families) {
         Ok(metrics) => Ok(metrics),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
@@ -14,7 +14,7 @@ use prometheus::{Counter, Encoder, Opts, Registry, TextEncoder};
 ///
 /// # Example
 ///
-/// ```
+/// ```compile_fail
 /// let metrics_registry = Registry::new();
 /// // register any metrics
 ///

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
@@ -65,6 +65,8 @@ mod test {
         .unwrap();
 
         registry.register(Box::new(counter.clone())).unwrap();
+        let expected_metric_count = 5 as f64;
+        counter.inc_by(expected_metric_count);
 
         let app = app(registry, counter);
         let response = app
@@ -82,7 +84,7 @@ mod test {
             &body[..],
             b"# HELP example_counter Reflects the number of times the greeter endpoint has been called.\n\
               # TYPE example_counter counter\n\
-              example_counter 0\n\
+              example_counter 5\n\
         ")
     }
 }

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
@@ -26,14 +26,9 @@ pub async fn report_metrics(
     Extension(metrics_registry): Extension<Registry>,
 ) -> Result<String, StatusCode> {
     // Gather the metrics.
-    let mut buffer = vec![];
     let encoder = TextEncoder::new();
     let metric_families = metrics_registry.gather();
-    if encoder.encode(&metric_families, &mut buffer).is_err() {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    match String::from_utf8(buffer) {
+    match encoder.encode_to_string(&metric_families) {
         Ok(metrics) => Ok(metrics),
         Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }

--- a/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
+++ b/chainsaw-demo/src/bin/chainsaw-demo-http/metrics.rs
@@ -1,0 +1,27 @@
+use crate::Result;
+
+use axum::extract::Extension;
+use hyper::StatusCode;
+use prometheus::{Counter, Encoder, Opts, Registry, TextEncoder};
+
+pub async fn report_metrics(
+    Extension(metrics_registry): Extension<Registry>,
+) -> Result<String, StatusCode> {
+    // Gather the metrics.
+    let mut buffer = vec![];
+    let encoder = TextEncoder::new();
+    let metric_families = metrics_registry.gather();
+    if let Err(_) = encoder.encode(&metric_families, &mut buffer) {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+
+    match String::from_utf8(buffer) {
+        Ok(metrics) => Ok(metrics),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+pub fn new_example_counter<S: Into<String>>(name: S, help: S) -> Result<Counter> {
+    let opts = Opts::new(name.into(), help.into());
+    Ok(Counter::with_opts(opts)?)
+}

--- a/chainsaw-demo/src/health.rs
+++ b/chainsaw-demo/src/health.rs
@@ -12,7 +12,7 @@ pub use tonic_health::{
 ///
 /// # Example
 ///
-/// ```
+/// ```compile_fail
 /// let (mut health_report, health_service) = health::reporter();
 /// chainsaw::health::set_global_status(health_report.clone(), ServingStatus::Serving).await;
 /// ```


### PR DESCRIPTION
Adds a module to `chainsaw-demo-http` to demonstrate exposition of metrics to a Prometheus scraper. The example counter is incremented whenever a request is made to the greeter endpoint: `service-host:port/{name}/{surname}`.